### PR TITLE
Optimize bulk saving of refined test cases

### DIFF
--- a/src/app/test-case-refiner/test-case-refiner.component.ts
+++ b/src/app/test-case-refiner/test-case-refiner.component.ts
@@ -418,7 +418,7 @@ export class TestCaseRefinerComponent implements OnInit, OnDestroy {
 
   private calculateStepChanges(
     tc: DetailedTestCase,
-    existingTc: DbTestCaseWithRelations,
+    existingTc: Partial<DbTestCaseWithRelations>,
     overrideTestCaseId?: string
   ): {
     stepsToInsert: { payload: { test_case_id: string; step_number: number; action: string }; tc: DetailedTestCase; stepIndex: number }[];

--- a/src/app/test-case-refiner/test-case-refiner.component.ts
+++ b/src/app/test-case-refiner/test-case-refiner.component.ts
@@ -272,7 +272,7 @@ export class TestCaseRefinerComponent implements OnInit, OnDestroy {
         const existingTc = existingTestCaseMap.get(tc.dbId)!;
         remainingTestCaseIds.delete(tc.dbId);
 
-        const updates = this.getTestCaseUpdates(tc, existingTc);
+        const updates = this.getTestCaseUpdates(tc, existingTc, userStoryId);
         if (Object.keys(updates).length > 1) { // includes id
           testCasesToUpdate.push(updates);
         }
@@ -406,8 +406,8 @@ export class TestCaseRefinerComponent implements OnInit, OnDestroy {
     });
   }
 
-  private getTestCaseUpdates(tc: DetailedTestCase, existingTc: DbTestCaseWithRelations): any {
-    const updates: any = { id: existingTc.id };
+  private getTestCaseUpdates(tc: DetailedTestCase, existingTc: DbTestCaseWithRelations, userStoryId: string): any {
+    const updates: any = { id: existingTc.id, user_story_id: existingTc.user_story_id || userStoryId };
 
     if (tc.title !== existingTc.title) updates.title = tc.title;
     if (tc.preconditions !== (existingTc.preconditions || '')) updates.preconditions = tc.preconditions;

--- a/src/app/test-case-refiner/test-case-refiner.component.ts
+++ b/src/app/test-case-refiner/test-case-refiner.component.ts
@@ -311,7 +311,8 @@ export class TestCaseRefinerComponent implements OnInit, OnDestroy {
         const target = testCasesToInsert[idx];
         if (target) {
           target.tc.dbId = inserted.id;
-          const { stepsToInsert } = this.calculateStepChanges(target.tc, { test_case_steps: [] } as DbTestCaseWithRelations, inserted.id);
+          const emptyExisting: Partial<DbTestCaseWithRelations> = { test_case_steps: [] };
+          const { stepsToInsert } = this.calculateStepChanges(target.tc, emptyExisting, inserted.id);
           stepInsertRequests.push(...stepsToInsert);
         }
       });


### PR DESCRIPTION
## Summary
- batch insert new refined test cases and steps instead of saving one by one
- batch update only modified test cases and steps while skipping untouched records
- clean up removed test cases/steps with set-based deletions to reduce round trips

## Testing
- Not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69273c540c0883329c35e8437a48c7c9)