### PR TITLE
fix: ensure delete persistence and optimistic UI for test plans/HUs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -54,8 +54,24 @@ Thumbs.db
 !.env.example
 !.env.sample
 
-# Específicamente para .env.local si solo usas ese
- .env.local
+# Angular/local environment overrides (secret-safe)
+src/environments/environment.local.ts
+src/environments/environment.*.local.ts
+
+# Common secret/certificate files
+*.pem
+*.key
+*.p12
+*.pfx
+*.crt
+*.cer
+*.mobileprovision
+
+# Token/config files that may contain credentials
+.envrc
+.secrets
+.secrets.*
+.npmrc
 
 # SQL scripts should not be committed
 *.sql

--- a/src/app/services/database/database.service.ts
+++ b/src/app/services/database/database.service.ts
@@ -466,9 +466,22 @@ export class DatabaseService {
       `);
 
       if (toDeleteIds.length > 0) {
-        const { error } = await this.supabase.from('user_stories').delete().in('id', toDeleteIds);
+        const { data: deletedHUs, error } = await this.supabase
+          .from('user_stories')
+          .delete()
+          .in('id', toDeleteIds)
+          .select('id');
+
         if (error) throw error;
-        console.log(`🗑️ ${toDeleteIds.length} HUs eliminadas`);
+
+        const deletedCount = deletedHUs?.length ?? 0;
+        if (deletedCount !== toDeleteIds.length) {
+          throw new Error(
+            `No se pudieron eliminar todas las HUs en BD. Esperadas: ${toDeleteIds.length}, eliminadas: ${deletedCount}`
+          );
+        }
+
+        console.log(`🗑️ ${deletedCount} HUs eliminadas`);
       }
 
       if (toInsert.length > 0) {
@@ -634,14 +647,22 @@ export class DatabaseService {
 
         if (deleteStepsError) throw deleteStepsError;
 
-        const { error: deleteCasesError } = await this.supabase
+        const { data: deletedCases, error: deleteCasesError } = await this.supabase
           .from('test_cases')
           .delete()
-          .in('id', tcsToDeleteIds);
+          .in('id', tcsToDeleteIds)
+          .select('id');
 
         if (deleteCasesError) throw deleteCasesError;
 
-        console.log(`🗑️ ${tcsToDeleteIds.length} TCs eliminados`);
+        const deletedCount = deletedCases?.length ?? 0;
+        if (deletedCount !== tcsToDeleteIds.length) {
+          throw new Error(
+            `No se pudieron eliminar todos los TCs en BD. Esperados: ${tcsToDeleteIds.length}, eliminados: ${deletedCount}`
+          );
+        }
+
+        console.log(`🗑️ ${deletedCount} TCs eliminados`);
       }
 
       if (tcsToInsert.length > 0) {
@@ -781,17 +802,23 @@ export class DatabaseService {
     console.log(`🗑️ Eliminando test plan ${id}...`);
 
     try {
-      const { error } = await this.supabase
+      const { data: deletedPlans, error } = await this.supabase
         .from('test_plans')
         .delete()
-        .eq('id', id);
+        .eq('id', id)
+        .select('id');
 
       if (error) {
         console.error('❌ Error al eliminar:', error);
         throw error;
       }
 
-      console.log('✅ Test plan eliminado');
+      const deletedCount = deletedPlans?.length ?? 0;
+      if (deletedCount === 0) {
+        throw new Error(`No se eliminó el test plan ${id}. Verifica políticas RLS/permisos.`);
+      }
+
+      console.log(`✅ Test plan eliminado (${deletedCount})`);
       return true;
 
     } catch (error) {

--- a/src/app/test-plan-viewer/test-plan-viewer.component.ts
+++ b/src/app/test-plan-viewer/test-plan-viewer.component.ts
@@ -1343,52 +1343,81 @@ export class TestPlanViewerComponent implements OnInit, OnDestroy {
     this.testPlanToDelete = null;
     this.testPlansToDelete = [];
 
+    const targetIds = plansToDelete
+      .map(plan => plan.id)
+      .filter((id): id is string => !!id);
+
+    if (targetIds.length === 0) {
+      this.toastService.error('No se encontró un ID válido para eliminar');
+      return;
+    }
+
+    // Optimistic UI: quitar de la vista en línea mientras se confirma en BD
+    const previousTestPlans = [...this.testPlans];
+    const previousSelectedPlanIds = [...this.selectedPlanIds];
+    const previousSelectedTestPlan = this.selectedTestPlan;
+
+    this.testPlans = this.testPlans.filter(plan => !plan.id || !targetIds.includes(plan.id));
+    this.selectedPlanIds = this.selectedPlanIds.filter(id => !targetIds.includes(id));
+    if (this.selectedTestPlan?.id && targetIds.includes(this.selectedTestPlan.id)) {
+      this.selectedTestPlan = null;
+    }
+    this.applyFilters();
+    this.cdr.detectChanges();
+
     const loadingToastId = this.toastService.loading(
       plansToDelete.length === 1 ? 'Eliminando test plan...' : `Eliminando ${plansToDelete.length} test plans...`
     );
 
     try {
-      let deletedCount = 0;
       const deletedIds: string[] = [];
+      const failedIds: string[] = [];
 
-      for (const plan of plansToDelete) {
-        if (!plan.id) continue;
-
-        const success = await this.databaseService.deleteTestPlan(plan.id);
+      for (const id of targetIds) {
+        const success = await this.databaseService.deleteTestPlan(id);
         if (success) {
-          deletedCount++;
-          deletedIds.push(plan.id);
+          deletedIds.push(id);
+        } else {
+          failedIds.push(id);
         }
       }
 
       this.toastService.dismiss(loadingToastId);
 
-      if (deletedCount > 0) {
-        if (deletedCount === plansToDelete.length) {
-          this.toastService.success(
-            deletedCount === 1
-              ? 'Test plan eliminado exitosamente'
-              : `${deletedCount} test plans eliminados exitosamente`
-          );
-        } else {
-          this.toastService.warning(
-            `Se eliminaron ${deletedCount} de ${plansToDelete.length} test plans`
-          );
-        }
-
-        await this.loadTestPlans(false);
-
-        this.selectedPlanIds = this.selectedPlanIds.filter(id => !deletedIds.includes(id));
-
-        if (this.selectedTestPlan?.id && deletedIds.includes(this.selectedTestPlan.id)) {
-          this.selectedTestPlan = null;
-        }
+      if (failedIds.length === 0) {
+        this.toastService.success(
+          deletedIds.length === 1
+            ? 'Test plan eliminado exitosamente'
+            : `${deletedIds.length} test plans eliminados exitosamente`
+        );
       } else {
-        this.toastService.error('Error al eliminar el test plan');
+        // Rehidratar estado real desde BD para evitar desalineación
+        await this.loadTestPlans(false);
+        this.selectedPlanIds = previousSelectedPlanIds.filter(id => this.testPlans.some(tp => tp.id === id));
+        this.selectedTestPlan = previousSelectedTestPlan?.id
+          ? (targetIds.includes(previousSelectedTestPlan.id) ? null : previousSelectedTestPlan)
+          : previousSelectedTestPlan;
+
+        this.toastService.warning(
+          `Se eliminaron ${deletedIds.length} de ${targetIds.length} test plans. Revisa permisos/políticas en BD.`
+        );
+        return;
       }
+
+      // Refrescar desde BD para reflejar estado persistido y contadores correctos
+      await this.loadTestPlans(false);
+      this.selectedPlanIds = this.selectedPlanIds.filter(id => !deletedIds.includes(id));
     } catch (error) {
       console.error('❌ Error:', error);
       this.toastService.dismiss(loadingToastId);
+
+      // Rollback local ante error inesperado
+      this.testPlans = previousTestPlans;
+      this.selectedPlanIds = previousSelectedPlanIds;
+      this.selectedTestPlan = previousSelectedTestPlan;
+      this.applyFilters();
+      this.cdr.detectChanges();
+
       this.toastService.error('Error al eliminar el test plan');
     }
   }


### PR DESCRIPTION
- Validate HU deletion with select() to confirm rows actually deleted from BD
- Validate test plan deletion with select() to prevent silent failures from RLS
- Add optimistic UI removal for test plan deletion (remove from view before BD confirm)
- Implement BD rehidration on delete failure to resync state
- Add rollback mechanism for delete operations with error recovery
- Improve gitignore to exclude credential-bearing files more robustly